### PR TITLE
Allow user access to recovery count and twi_maxloops parameters

### DIFF
--- a/src/SBWire.cpp
+++ b/src/SBWire.cpp
@@ -17,6 +17,10 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+  Modified 2017 by Chuck Todd (ctodd@cableone.net) to correct Unconfigured Slave Mode reboot
+  Modified 2017 by Shuning Bian (freespace@gmail.com ) to prevent while() loop deadlocks
+  Modified 2018 by Frank Paynter (paynterf@gmail.com) to add user access to twi_maxloops parameter
+
 */
 
 extern "C" {
@@ -50,6 +54,28 @@ TwoWire::TwoWire()
 }
 
 // Public Methods //////////////////////////////////////////////////////////////
+
+//08/22/18 gfp: added for lockup prevention parameter access
+void TwoWire::clearRecoveryCount()
+{
+	twi_clearRecoveryCount();
+}
+
+uint16_t TwoWire::getRecoveryCount()
+{
+	return twi_getRecoveryCount();
+}
+
+void TwoWire::setTwiMaxLoops(uint16_t maxloops)
+{
+	twi_setMaxLoops(maxloops);
+}
+
+uint16_t TwoWire::getTwiMaxLoops()
+{
+	return twi_getMaxLoops();
+}
+
 
 void TwoWire::begin(void)
 {

--- a/src/SBWire.h
+++ b/src/SBWire.h
@@ -17,6 +17,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+  Modified 2017 by Shuning Bian (freespace@gmail.com ) to prevent while() loop deadlocks
+  Modified 2018 by Frank Paynter (paynterf@gmail.com) to add user access to twi_maxloops parameter
 */
 
 #ifndef TwoWire_h
@@ -71,6 +73,12 @@ class TwoWire : public Stream
     virtual void flush(void);
     void onReceive( void (*)(int) );
     void onRequest( void (*)(void) );
+
+	//08/22/18 gfp: added for lockup parameter access
+	void clearRecoveryCount();
+	uint16_t getRecoveryCount();
+	void setTwiMaxLoops(uint16_t maxloops);
+	uint16_t getTwiMaxLoops();
 
     inline size_t write(unsigned long n) { return write((uint8_t)n); }
     inline size_t write(long n) { return write((uint8_t)n); }

--- a/src/utility/twi.h
+++ b/src/utility/twi.h
@@ -15,7 +15,11 @@
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*/
+
+  Modified 2017 by Steve Bian (notifications@github.com) to prevent while() loop deadlocks
+  Modified 2018 by Frank Paynter (paynterf@gmail.com) to add user access to twi_maxloops parameter
+
+  */
 
 #ifndef twi_h
 #define twi_h
@@ -52,5 +56,8 @@
   void twi_releaseBus(void);
 
   void twi_setMaxLoops(uint16_t maxloops);
+  uint16_t twi_getMaxLoops();
+  uint16_t twi_getRecoveryCount(); //08/22/18 gfp for monitoring purposes
+  void twi_clearRecoveryCount(); //08/22/18 gfp for monitoring purposes
 #endif
 


### PR DESCRIPTION
- prevent I2C while() loop lockups
- allow user get/set access to recovery count
- allow user get/set access to twi_maxloops parameter